### PR TITLE
Sets final announcement length to 10 seconds

### DIFF
--- a/app/src/main/java/com/boarbeard/generator/beimax/event/Announcement.java
+++ b/app/src/main/java/com/boarbeard/generator/beimax/event/Announcement.java
@@ -76,7 +76,7 @@ public class Announcement implements Event {
 		case ANNOUNCEMENT_PH3_TWENTYSECS:
 			return 5;
 		case ANNOUNCEMENT_PH3_ENDS:
-			return 12;
+			return 10;
 		}
 		return -1; // error
 	}


### PR DESCRIPTION
Sets final announcement "Mission ends in 5, 4, 3, 2, 1. Mission
complete" to 10 seconds instead of 12. This causes the time of the this
announcement to match the time in the mission cards. Otherwise 
the time is off by 2 seconds.
