### PR TITLE
Does not clear mission log after resume

### DIFF
--- a/app/src/main/java/com/boarbeard/audio/MediaPlayerMainMission.java
+++ b/app/src/main/java/com/boarbeard/audio/MediaPlayerMainMission.java
@@ -54,9 +54,10 @@ public class MediaPlayerMainMission extends MediaPlayerSequence {
 	}
 
 	public synchronized void start() {
-        // Clear the mission introduction
-        missionLog = "";
-
+        // Clear the mission introduction when the mission is started (not resumed after a pause)
+        if (stopWatch.missionTimeInNanos() == 0) {
+            missionLog = "";
+        }
 		if (mediaPlayerList.size() <= playerIndex) {
 			init();
 		}


### PR DESCRIPTION
The mission log was erroneously cleared after each resume.
The log is now only cleared when the mission is started.
