### PR TITLE
Adds option to restore default values in options screen

### DIFF
--- a/app/src/main/java/com/boarbeard/generator/beimax/MissionImpl.java
+++ b/app/src/main/java/com/boarbeard/generator/beimax/MissionImpl.java
@@ -237,9 +237,17 @@ public class MissionImpl implements IMission {
             prefs.threatLevel -= CONSTANT_THREAT_UNCONFIRMED; // if 4 players, then you have to subtract the unconfirmed part from the base level (8 - 1 = 7 in normal missions)
         }
 
-        prefs.minIncomingData = preferences.getInt("numberIncomingDataSecondValue", prefs.minIncomingData);
-        prefs.maxIncomingData = preferences.getInt("numberIncomingData", prefs.maxIncomingData);
+        prefs.minIncomingData = preferences.getInt("numberIncomingData", prefs.minIncomingData);
+        prefs.maxIncomingData = preferences.getInt("numberIncomingDataSecondValue", prefs.maxIncomingData);
 
+        // Make sure maxIncomingData is always greater than minIncomingData. Earlier version
+        // of the app might have switched these values. This check prevents a crash when users
+        // upgrade from an older version.
+        if (prefs.minIncomingData > prefs.maxIncomingData) {
+            int tempIncomingData = prefs.minIncomingData;
+            prefs.minIncomingData = prefs.maxIncomingData;
+            prefs.maxIncomingData = tempIncomingData;
+        }
 
         int missionLength = preferences.getInt("missionLengthPreference", 600);
         prefs.minPhaseTime[0] = (int) (missionLength * .4);

--- a/app/src/main/java/com/boarbeard/ui/PreferencesActivity.java
+++ b/app/src/main/java/com/boarbeard/ui/PreferencesActivity.java
@@ -42,44 +42,42 @@ public class PreferencesActivity extends PreferenceActivity implements
 		addPreferencesFromResource(R.xml.preferences);
 
 		onCreateVoicePreferences();
-        initRestoreDefaultSettings();
+        initRestoreDefaultButton();
 	}
 
     /*
-     * Handles the restore default settings option
+     * Initiates the button restore default settings button 
      */
-    private void initRestoreDefaultSettings() {
-        Preference restoreButton = (Preference)findPreference("restoreDefaultSettings");
-        if (restoreButton!=null) {
-            restoreButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
-                @Override
-                public boolean onPreferenceClick(Preference arg0) {
-                    CheckBoxPreference unconfirmedReports = (CheckBoxPreference)
-                            (Preference)findPreference("unconfirmedReportsPreference");
-                    if (unconfirmedReports != null) {
-                        unconfirmedReports.setChecked(getResources().
-                                getBoolean(R.bool.pref_unconfirmed_reports_default_value));
-                    }
+    private void initRestoreDefaultButton() {
+        Preference restoreButton = findPreference("restoreDefaultSettings");
 
-                    SeekBarPreference missionLength = (SeekBarPreference)
-                            findPreference("missionLengthPreference");
-                    if (missionLength != null) {
-                        missionLength.restoreDefaultValues();
-                    }
-                    SeekBarPreference threatDifficulty = (SeekBarPreference)
-                            findPreference("threatDifficultyPreference");
-                    if (threatDifficulty != null) {
-                        threatDifficulty.restoreDefaultValues();
-                    }
-                    SeekBarPreference nbrIncommingData = (SeekBarPreference)
-                            findPreference("numberIncomingData");
-                    if (nbrIncommingData != null) {
-                        nbrIncommingData.restoreDefaultValues();
-                    }
-                    return true;
-                }
-            });
-        }
+            // Configure the behavior when the user pressed the restore default setting button.
+        restoreButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference arg0) {
+                // Restore unconfirmed reports setting to default value
+                CheckBoxPreference unconfirmedReports = (CheckBoxPreference)
+                        findPreference("unconfirmedReportsPreference");
+                unconfirmedReports.setChecked(getResources().
+                    getBoolean(R.bool.pref_unconfirmed_reports_default_value));
+
+                // Restore mission length setting to default value.
+                SeekBarPreference missionLength = (SeekBarPreference)
+                        findPreference("missionLengthPreference");
+                missionLength.restoreDefaultValues();
+
+                // Restore threat difficulty setting to default value.
+                SeekBarPreference threatDifficulty = (SeekBarPreference)
+                        findPreference("threatDifficultyPreference");
+                threatDifficulty.restoreDefaultValues();
+                
+                // Restore Incoming data settings to default value
+                SeekBarPreference nbrIncomingData = (SeekBarPreference)
+                        findPreference("numberIncomingData");
+                nbrIncomingData.restoreDefaultValues();
+                return true;
+            }
+        });
     }
 
     private void onCreateVoicePreferences() {

--- a/app/src/main/java/com/boarbeard/ui/PreferencesActivity.java
+++ b/app/src/main/java/com/boarbeard/ui/PreferencesActivity.java
@@ -6,13 +6,16 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.net.Uri;
 import android.os.Bundle;
+import android.preference.CheckBoxPreference;
 import android.preference.ListPreference;
 import android.preference.PreferenceActivity;
+import android.preference.Preference;
 
 import com.boarbeard.R;
 import com.boarbeard.audio.parser.DefaultGrammar;
 import com.boarbeard.audio.parser.EventListParserFactory;
 import com.boarbeard.io.ExternalMedia;
+import com.boarbeard.ui.widget.SeekBarPreference;
 
 public class PreferencesActivity extends PreferenceActivity implements
 		OnSharedPreferenceChangeListener {
@@ -39,9 +42,47 @@ public class PreferencesActivity extends PreferenceActivity implements
 		addPreferencesFromResource(R.xml.preferences);
 
 		onCreateVoicePreferences();
+        initRestoreDefaultSettings();
 	}
 
-	private void onCreateVoicePreferences() {
+    /*
+     * Handles the restore default settings option
+     */
+    private void initRestoreDefaultSettings() {
+        Preference restoreButton = (Preference)findPreference("restoreDefaultSettings");
+        if (restoreButton!=null) {
+            restoreButton.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+                @Override
+                public boolean onPreferenceClick(Preference arg0) {
+                    CheckBoxPreference unconfirmedReports = (CheckBoxPreference)
+                            (Preference)findPreference("unconfirmedReportsPreference");
+                    if (unconfirmedReports != null) {
+                        unconfirmedReports.setChecked(getResources().
+                                getBoolean(R.bool.pref_unconfirmed_reports_default_value));
+                    }
+
+                    SeekBarPreference missionLength = (SeekBarPreference)
+                            findPreference("missionLengthPreference");
+                    if (missionLength != null) {
+                        missionLength.restoreDefaultValues();
+                    }
+                    SeekBarPreference threatDifficulty = (SeekBarPreference)
+                            findPreference("threatDifficultyPreference");
+                    if (threatDifficulty != null) {
+                        threatDifficulty.restoreDefaultValues();
+                    }
+                    SeekBarPreference nbrIncommingData = (SeekBarPreference)
+                            findPreference("numberIncomingData");
+                    if (nbrIncommingData != null) {
+                        nbrIncommingData.restoreDefaultValues();
+                    }
+                    return true;
+                }
+            });
+        }
+    }
+
+    private void onCreateVoicePreferences() {
 		ListPreference listPreferenceCategory = (ListPreference) findPreference("voice_choices");
 		if (listPreferenceCategory != null) {
 			List<Uri> mediaFolderList = ExternalMedia.getMediaFolders(this);

--- a/app/src/main/java/com/boarbeard/ui/widget/SeekBarPreference.java
+++ b/app/src/main/java/com/boarbeard/ui/widget/SeekBarPreference.java
@@ -128,11 +128,11 @@ public class SeekBarPreference extends DialogPreference implements com.boarbeard
 			boolean knobEndChanged, int knobStart, int knobEnd) {
 		
 		if(knobEnd > knobStart) {
+			mCurrentValue = knobStart;
+			mCurrentSecondValue = knobEnd;
+		} else {
 			mCurrentValue = knobEnd;
 			mCurrentSecondValue = knobStart;
-		} else {
-			mCurrentValue = knobStart;
-			mCurrentSecondValue = knobEnd;	
 		}
 		
 		if (!mSeekBar.isSecondThumbEnabled() && knobEndChanged) {

--- a/app/src/main/java/com/boarbeard/ui/widget/SeekBarPreference.java
+++ b/app/src/main/java/com/boarbeard/ui/widget/SeekBarPreference.java
@@ -152,4 +152,17 @@ public class SeekBarPreference extends DialogPreference implements com.boarbeard
 		return min + " - " + max;
 	}
 
+    public void restoreDefaultValues() {
+        // Restore the first value
+        mCurrentValue = mDefaultValue;
+        persistInt(mCurrentValue);
+
+        // Restore the second value
+        mCurrentSecondValue = mDefaultSecondValue;
+        SharedPreferences settings = PreferenceManager.getDefaultSharedPreferences(this.getContext());
+        settings.edit().putInt(getKey() + "SecondValue", mCurrentSecondValue).commit();
+
+        // Notify that the values has been updated
+        notifyChanged();
+    }
 }

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="pref_unconfirmed_reports_default_value">false</bool>
+    <integer name="pref_mission_length_default_value">540</integer>
+    <integer name="pref_threat_difficulty_default_value">8</integer>
+    <integer name="pref_threat_incoming_data_default_value">2</integer>
+    <integer name="pref_threat_incoming_data_default_second_value">4</integer>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,8 +9,9 @@
     <string name="mission_options">Options</string>
     <string name="mission_type">Type</string>
     
-    <string name="pref_mission">Mission Parameters</string>
+    <string name="pref_mission">Parameters for Random Mission</string>
     <string name="pref_mission_voice">Language</string>
+    <string name="pref_display_settings">Display Settings</string>
     <string name="pref_unconfirmedReports_title">Unconfirmed Reports</string>
     <string name="pref_unconfirmedReports_summary">Whether to allow chance of unconfirmed reports to the mission.</string>
   	<string name="pref_mission_length_summary">The approximate mission length in seconds.</string>
@@ -19,6 +20,8 @@
 	<string name="pref_mission_length_dialog_title">Mission Length</string>   
   	<string name="pref_threat_difficulty_dialog_title">Threat Difficulty</string>   	
   	<string name="pref_threat_difficulty_summary">Cumulative threat for the mission. (Normal=1, Serious=2)</string>
+    <string name="pref_restore_default_settings_title">Restore</string>
+    <string name="pref_restore_default_settings_summary">Restore default settings</string>
   	<string name="pref_voice_title">Sound Pack</string>   	
   	<string name="pref_voice_summary">Sound files and Text to use. See read me in com.boarbeard on storage to add your own.</string>  	
  	<string name="pref_incoming_data_title">Incoming Data: %1$d - %2$d</string>   	

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -7,7 +7,7 @@
 			android:title="@string/pref_unconfirmedReports_title"
 			android:summary="@string/pref_unconfirmedReports_summary" />
 		<com.boarbeard.ui.widget.SeekBarPreference
-            android:defaultValue="540"
+            android:defaultValue="@integer/pref_mission_length_default_value"
             android:dialogTitle="@string/pref_mission_length_dialog_title"
             android:key="missionLengthPreference"
             widget:maxValue="840"
@@ -17,7 +17,7 @@
             android:summary="@string/pref_mission_length_summary"
             android:title="@string/pref_mission_length_title" />
         <com.boarbeard.ui.widget.SeekBarPreference
-            android:defaultValue="8"
+            android:defaultValue="@integer/pref_threat_difficulty_default_value"
             android:dialogTitle="@string/pref_threat_difficulty_dialog_title"
             android:key="threatDifficultyPreference"
             widget:maxValue="14"
@@ -26,8 +26,8 @@
             android:summary="@string/pref_threat_difficulty_summary"
             android:title="@string/pref_threat_difficulty_title" />
         <com.boarbeard.ui.widget.SeekBarPreference
-            android:defaultValue="2"
-            widget:defaultSecondValue="4"
+            android:defaultValue="@integer/pref_threat_incoming_data_default_value"
+            widget:defaultSecondValue="@integer/pref_threat_incoming_data_default_second_value"
             android:dialogTitle="@string/pref_incoming_data_dialog_title"
             android:key="numberIncomingData"
             widget:maxValue="6"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -35,12 +35,18 @@
             android:persistent="true"
             android:summary="@string/pref_incoming_data_summary"
             android:title="@string/pref_incoming_data_title" />
+        <Preference android:title="@string/pref_restore_default_settings_title"
+            android:key="restoreDefaultSettings"
+            android:summary="@string/pref_restore_default_settings_summary"/>
+
+    </PreferenceCategory>
+    <PreferenceCategory android:title="@string/pref_display_settings">
         <CheckBoxPreference android:key="logColorsPreference"
 			android:defaultValue="true"
 			android:title="@string/pref_logColors_title"
 			android:persistent="true"
         	android:summary="@string/pref_logColors_summary" />        
-</PreferenceCategory>
+    </PreferenceCategory>
 	<PreferenceCategory android:title="@string/pref_mission_voice">
 		<ListPreference android:key="voice_choices" android:title="@string/pref_voice_title" android:summary="@string/pref_voice_summary"
             android:defaultValue="0" />


### PR DESCRIPTION
Adds options to restore default values in options screen.
Clarifies title to show that the setting only affects random
missions.
Moves the setting "Log Colors" to a separate group since this
setting affects all missions, not just random missions.
