### PR TITLE
Fixes crash when clearing mission log

### DIFF
--- a/app/src/main/java/com/boarbeard/audio/MediaPlayerMainMission.java
+++ b/app/src/main/java/com/boarbeard/audio/MediaPlayerMainMission.java
@@ -60,6 +60,7 @@ public class MediaPlayerMainMission extends MediaPlayerSequence {
         // Clear the mission introduction when the mission is started (not resumed after a pause)
         if (stopWatch.missionTimeInNanos() == 0) {
             missionLog.clear();
+            missionActivity.clearMissionLog();
         }
         if (mediaPlayerList.size() <= playerIndex) {
             init();


### PR DESCRIPTION
Fixes crash when clearing a mission log with an introduction
message by also calling missionActivity.clearMissionLog
