### PR TITLE
#32 - HTML span tag for color and volume keys

### DIFF
--- a/app/src/main/java/com/boarbeard/audio/MediaPlayerMainMission.java
+++ b/app/src/main/java/com/boarbeard/audio/MediaPlayerMainMission.java
@@ -236,7 +236,7 @@ public class MediaPlayerMainMission extends MediaPlayerSequence {
      * Prints the mission introduction to the log.
     */
     public void printMissionIntroduction(String missionIntroduction) {
-        missionLog.add(new MissionLog(Html.fromHtml("<b><i> <p style=\"color:#C7EBFC;\">" + missionIntroduction + "</p></i></b>")));
+        missionLog.add(new MissionLog(Html.fromHtml("<b><i><span style=\"color:#C7EBFC;\">" + missionIntroduction + "</span></i></b>")));
         missionActivity.updateMissionLog(missionLog.size() - 1);
     }
 

--- a/app/src/main/java/com/boarbeard/ui/MissionActivity.java
+++ b/app/src/main/java/com/boarbeard/ui/MissionActivity.java
@@ -8,6 +8,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.graphics.BitmapFactory;
+import android.media.AudioManager;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
@@ -67,6 +68,10 @@ public class MissionActivity extends AppCompatActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main);
+
+        //  When people hit the volume buttons, we want to change the media
+        //  volume, not the ringtone volume.
+        setVolumeControlStream(AudioManager.STREAM_MUSIC);
 
         stopWatch = new StopWatch(
                 (TextView) findViewById(R.id.missionClockTextView));


### PR DESCRIPTION
Here are two minor changes, although thanks to DOS line terminators getting stripped, it's hard to tell.

- use `<span>` instead of `<p>` to set the text color in MediaPlayerMainMission.java line 239 (on my device, `<p>` adds a blank line after the text)
- if the user presses the volume keys while the audio's not running, adjust the media volume instead of the ringtone volume

If you want me to restore the CRLF in MediaPlayerMainMission.java to make the change more obvious, I will be happy to do so.  (I still don't know whether Git or Android Studio did that; I'm on Linux with git's `core.autocrlf=input`.  I haven't used a Microsoft OS since 1996!)